### PR TITLE
Allow specifying VIRTUAL_ALIASMAP as pcre table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x \
 # Install packages
 RUN set -x \
   && apt-get update \
-  && apt-get install -y --no-install-recommends postfix mailutils busybox-syslogd opendkim opendkim-tools libsasl2-modules curl ca-certificates procps \
+  && apt-get install -y --no-install-recommends postfix postfix-pcre mailutils busybox-syslogd opendkim opendkim-tools libsasl2-modules curl ca-certificates procps \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   ;

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Relay host parameters:
 Virtual alias map:
 
 - `VIRTUAL_ALIASMAP` - virtual alias map in format: `VIRTUAL_ALIASMAP=alias@domain1.com:user@domain2.com,no-reply@somedomain.com:devnull`
+- `VIRTUAL_ALIASMAP_PCRE` - If "true" allows specifying virtual alias map as pcre_table
 
 TLS parameters:
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -136,7 +136,11 @@ if [ -n "${VIRTUAL_ALIASMAP}" ]; then
         echo "${ALIAS} ${DST}" >> /etc/postfix/virtual
     done
     postmap /etc/postfix/virtual
-    postconf -e virtual_alias_maps=hash:/etc/postfix/virtual
+    if [[ "${VIRTUAL_ALIASMAP_PCRE}" == "true" ]]; then
+        postconf -e virtual_alias_maps=pcre:/etc/postfix/virtual
+    else
+        postconf -e virtual_alias_maps=hash:/etc/postfix/virtual
+    fi
 fi
 
 # exit cleanly


### PR DESCRIPTION
Hey,

thanks for docker-postfix!

I needed to specify the virtual alias map as pcre_table, so I added a new environment argument `VIRTUAL_ALIASMAP_PCRE`

Cheers
