### PR TITLE
Add option to specify passwordmap file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Relay host parameters:
 - `RELAYHOST` - Postfix `relayhost`. Default ''. (example `mail.example.com:25`)
 - `RELAYHOST_AUTH` - Enable authentication for relayhost. Generally used with `RELAYHOST_PASSWORDMAP`. Default `no`.
 - `RELAYHOST_PASSWORDMAP` - relayhost password map in format: `RELAYHOST_PASSWORDMAP=mail1.example.com:user1:pass2,mail2.example.com:user2:pass2`
+- `RELAYHOST_PASSWORDMAP_FILE` - relayhost password map file, content is copied into RELAYHOST_PASSWORDMAP. Useful in combination with docker secrets.
 
 Virtual alias map:
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -91,6 +91,16 @@ if [ "${RELAYHOST_AUTH}" == "yes" ]; then
     postconf -e smtp_sasl_mechanism_filter="PLAIN LOGIN"
 fi
 
+if [ -n "${RELAYHOST_PASSWORDMAP_FILE}" ]; then
+  echo "postfix >> Reading password map file: ${RELAYHOST_PASSWORDMAP_FILE}"
+  if [ -e "${RELAYHOST_PASSWORDMAP_FILE}" ]; then
+    RELAYHOST_PASSWORDMAP=$(cat $RELAYHOST_PASSWORDMAP_FILE)
+    echo "postfix >> Read password map "
+  else
+    echo "postfix >> Specified password map file not found!"
+  fi
+fi
+
 if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     echo "postfix >> Generating relayhost password map"
     truncate --size 0 /etc/postfix/sasl-passwords


### PR DESCRIPTION
This PR allows you to specify the `RELAYHOST_PASSWORDMAP` in a file so it can be used with docker secrets as follows:

docker-compose.yml:

```yaml
services:
  postfix:
    image: ....
    environment:
      RELAY_AUTH: 'yes'
      RELAYHOST_PASSWORDMAP_FILE: /run/secrets/relay_passwordmap
secrets:
  relay_passwordmap:
    external: true
```